### PR TITLE
Change log message format

### DIFF
--- a/internal/pac.go
+++ b/internal/pac.go
@@ -39,7 +39,7 @@ func (pac *PAC) Evaluate(r *http.Request) (*url.URL, error) {
 
 	if err == nil {
 
-		reqLogger.Infof("%s %s %s", r.Method, r.Proto, r.URL.String())
+		reqLogger.Infof("%s %s", r.Method, r.URL.String())
 
 		fields := strings.Fields(proxy)
 		if len(fields) == 0 {

--- a/main.go
+++ b/main.go
@@ -16,6 +16,11 @@ func init() {
 	log.SetOutput(os.Stdout)
 	log.SetLevel(log.DebugLevel)
 	log.SetReportCaller(false)
+
+	formatter := new(log.TextFormatter)
+	formatter.FullTimestamp = true
+	formatter.TimestampFormat = "15:04:05"
+	log.SetFormatter(formatter)
 }
 
 func usage() {
@@ -30,8 +35,8 @@ func main() {
 	flag.Parse()
 
 	if flag.NArg() == 0 {
-	    flag.Usage()
-	    os.Exit(1)
+		flag.Usage()
+		os.Exit(1)
 	}
 
 	pac := internal.PAC{


### PR DESCRIPTION
- Drop HTTP protocol from log messages
- Use a short timestamp with format `%H:%M:%S`