### PR TITLE
Close both connections in go routine

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -56,7 +56,6 @@ func (proxy *Proxy) Http(w http.ResponseWriter, r *http.Request) {
 
 	w.WriteHeader(resp.StatusCode)
 
-	// Ignore benign errors for closed connections
 	io.Copy(w, resp.Body)
 }
 
@@ -127,8 +126,12 @@ func (proxy *Proxy) HttpConnect(w http.ResponseWriter, r *http.Request) {
 	}
 	defer clientConn.Close()
 
-	// Ignore benign errors for closed connections
-	go io.Copy(clientConn, serverConn)
+	go func() {
+		io.Copy(clientConn, serverConn)
+		clientConn.Close()
+		serverConn.Close()
+	}()
+
 	io.Copy(serverConn, clientConn)
 }
 


### PR DESCRIPTION
Fixes a bug where the `io.Copy` call inside the go routine terminates but the `io.Copy` outside does not. Under the right circumstances, this causes connectivity issues due to leaving a unidirectional connection open.