### PR TITLE
Add examples to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,59 @@ curl https://github.com
 ### Options
 
 ```
-Usage: paxy [options] pac_file ...
+Usage: paxy [options] pac_file
   -p int
     	The port on which the server listens (default 8228)
 ```
+
+### Examples
+
+#### Pairing `paxy` with `cntlm`
+
+Some corporate networks require users to access the internet through an HTTP
+proxy that uses the NTLM protocol for authentication. `cntlm` handles NTLM
+authentication and allows an unauthenticated HTTP proxy to be exposed on
+localhost. However, if your network has complicated rules then they will be
+difficult to express in the configuration file for `cntlm`.
+
+Instead you can express your proxy rules in a PAC file and forward HTTP
+connections that need to go through the corporate proxy to `cntlm` instead.
+
+```js
+function FindProxyForURL(url, host) {
+  if (shExpMatch(host, "*.internal.example.com")) {
+    return "DIRECT";
+  }
+
+  return "HTTP 127.0.0.1:3128";
+}
+```
+
+#### SSH dynamic port forwarding
+
+SSH dynamic port forwarding exposes a SOCKS proxy that allows you to tunnel
+traffic through another host via SSH.
+
+For example, if a section of your network has the domain name suffix
+`.private.example.com` which is only accessible via the host `remote-host`, you
+can create the dynamic port forward with:
+
+```bash
+ssh -D 8229 remote-host
+```
+
+The use the following PAC file:
+
+```js
+function FindProxyForURL(url, host) {
+  if (shExpMatch(host, "*.private.example.com")) {
+    return "SOCKS5 127.0.0.1:8229";
+  }
+
+  return "DIRECT";
+}
+```
+
+This will route all HTTP connections to `*.private.example.com` via
+`remote-host` while all other HTTP connections are made from your host
+directly.

--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ func init() {
 }
 
 func usage() {
-	fmt.Printf("Usage: %s [options] pac_file ...\n", os.Args[0])
+	fmt.Printf("Usage: %s [options] pac_file\n", os.Args[0])
 	flag.PrintDefaults()
 }
 


### PR DESCRIPTION
Adds some detailed examples to explain how to use `paxy` file with both `cntlm` and `ssh` dynamic port forwarding.